### PR TITLE
enable parallelization

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -1,5 +1,6 @@
 library(targets)
 
+options(clustermq.scheduler = "multicore")
 options(tidyverse.quiet = TRUE, timeout = 500)
 tar_option_set(packages = c("tidyverse","sbtools","sf",'dataRetrieval',"nhdplusTools",
                             'dplyr','readxl','readr','stringr','mapview',


### PR DESCRIPTION
I was just trying to re-run this pipeline in the docker image, and since it has a lot to do I wanted to parallelize it a bit. Targets makes this easy to do (see [here](https://dsp-manual.wma.chs.usgs.gov/docs/tutorials/simple_targets_parallelization/) for details).

This PR enables targets to run multiple workers in parallel. For instance, in order to run the pipeline with four workers, you would run `targets::tar_make_clustermq(workers = 4)`.

The pipeline will still run in exactly the same way as before if you run `targets::tar_make()`.